### PR TITLE
Add MIN_TARGET_COVERAGE to HsMetrics

### DIFF
--- a/src/main/java/picard/analysis/directed/PanelMetricsBase.java
+++ b/src/main/java/picard/analysis/directed/PanelMetricsBase.java
@@ -82,6 +82,9 @@ public class PanelMetricsBase extends MultilevelMetrics {
     /** The maximum coverage of reads that mapped to target regions of an experiment. */
     public long MAX_TARGET_COVERAGE;
 
+    /** The minimum coverage of reads that mapped to target regions of an experiment. */
+    public long MIN_TARGET_COVERAGE;
+
     /** The fraction of targets that did not reach coverage=1 over any base. */
     public double ZERO_CVG_TARGETS_PCT;
 

--- a/src/main/java/picard/analysis/directed/TargetMetricsCollector.java
+++ b/src/main/java/picard/analysis/directed/TargetMetricsCollector.java
@@ -665,6 +665,9 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
             // the maximum depth at any target base
             long maxDepth = 0;
 
+            // the minimum depth at any target base
+            long minDepth = Long.MAX_VALUE;
+
             // The "how many target bases at at-least X" calculations.
             // downstream code relies on this array being sorted in ascending order
             final int[] targetBasesDepth = {0, 1, 2, 10, 20, 30, 40, 50, 100};
@@ -679,6 +682,7 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
                     zeroCoverageTargets++;
                     highQualityCoverageHistogramArray[0] += c.interval.length();
                     targetBases[0] += c.interval.length();
+                    minDepth = 0;
                     continue;
                 }
 
@@ -686,6 +690,7 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
                     totalCoverage += depth;
                     highQualityCoverageHistogramArray[Math.min(depth, coverageCap)]++;
                     maxDepth = Math.max(maxDepth, depth);
+                    minDepth = Math.min(minDepth, depth);
 
                     // Add to the "how many target bases at at-least X" calculations.
                     for (int i = 0; i < targetBasesDepth.length; i++) {
@@ -707,6 +712,7 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
             metrics.MEAN_TARGET_COVERAGE = (double) totalCoverage / metrics.TARGET_TERRITORY;
             metrics.MEDIAN_TARGET_COVERAGE = highQualityDepthHistogram.getMedian();
             metrics.MAX_TARGET_COVERAGE = maxDepth;
+            metrics.MIN_TARGET_COVERAGE = Math.min(minDepth, maxDepth);
 
             // compute the coverage value such that 80% of target bases have better coverage than it i.e. 20th percentile
             // this roughly measures how much we must sequence extra such that 80% of target bases have coverage at least as deep as the current mean coverage

--- a/src/main/java/picard/analysis/directed/TargetMetricsCollector.java
+++ b/src/main/java/picard/analysis/directed/TargetMetricsCollector.java
@@ -712,6 +712,7 @@ public abstract class TargetMetricsCollector<METRIC_TYPE extends MultilevelMetri
             metrics.MEAN_TARGET_COVERAGE = (double) totalCoverage / metrics.TARGET_TERRITORY;
             metrics.MEDIAN_TARGET_COVERAGE = highQualityDepthHistogram.getMedian();
             metrics.MAX_TARGET_COVERAGE = maxDepth;
+            // Use Math.min() to account for edge case where highQualityCoverageByTarget is empty (minDepth=Long.MAX_VALUE)
             metrics.MIN_TARGET_COVERAGE = Math.min(minDepth, maxDepth);
 
             // compute the coverage value such that 80% of target bases have better coverage than it i.e. 20th percentile

--- a/src/test/java/picard/analysis/directed/CollectHsMetricsTest.java
+++ b/src/test/java/picard/analysis/directed/CollectHsMetricsTest.java
@@ -42,12 +42,13 @@ public class CollectHsMetricsTest extends CommandLineProgramTest {
                 {TEST_DIR + "/overlapping.sam", intervals, 0, 0, true,  2, 202, 0,   0.5, 0.505, 0, 1, 0, 202, 1000},
                 // test that we do not clip overlapping bases
                 {TEST_DIR + "/overlapping.sam", intervals, 0, 0, false, 2, 202, 0,   0.0, 0.505, 0.505, 2, 0, 202, 1000},
-                // A shorter interval that is completely covered by the read.
-                // test that minimum coverage increases from zero when interval is completely covered by the read
-                // test that pct 1x (and 2x if counting overlap) coverage increases when the interval is completely covered by the read
+                // test that we exclude half of the bases (due to poor quality) with an interval that is completely covered
                 {TEST_DIR + "/lowbaseq.sam",    halfIntervals, 1, 10, true,  2, 200, 0.5, 0.0, 1.0, 0.0,  1, 1, 200, 1000},
+                // test that read 2 (with mapping quality 1) is filtered out with minimum mapping quality 2 with an interval that is completely covered
                 {TEST_DIR + "/lowmapq.sam",     halfIntervals, 2, 0, true,  2, 202, 0,   0.0, 1.0, 0.0,   1, 1, 202, 1000},
+                // test that we clip overlapping bases with an interval that is completely covered
                 {TEST_DIR + "/overlapping.sam", halfIntervals, 0, 0, true,  2, 202, 0,   0.5, 1.0, 0, 1, 1, 202, 1000},
+                // test that we do not clip overlapping bases with an interval that is completely covered
                 {TEST_DIR + "/overlapping.sam", halfIntervals, 0, 0, false, 2, 202, 0,   0.0, 1.0, 1.0, 2, 2, 202, 1000},
                 // A read 10 base pairs long. two intervals: one maps identically to the read, other does not overlap at all
                 {TEST_DIR + "/single-short-read.sam", twoSmallIntervals, 20, 20, true, 1, 10, 0.0, 0.0, 0.5, 0.0, 1, 0, 10, 1000 }

--- a/src/test/java/picard/analysis/directed/CollectHsMetricsTest.java
+++ b/src/test/java/picard/analysis/directed/CollectHsMetricsTest.java
@@ -36,19 +36,21 @@ public class CollectHsMetricsTest extends CommandLineProgramTest {
                 // two reads, each has 100 bases. bases in one read are medium quality (20), in the other read poor quality (10).
                 // test that we exclude half of the bases
                 {TEST_DIR + "/lowbaseq.sam",    intervals, 1, 10, true,  2, 200, 0.5, 0.0, 0.50, 0.0,  1, 0, 200, 1000},
-                {TEST_DIR + "/lowbaseq.sam",    halfIntervals, 1, 10, true,  2, 200, 0.5, 0.0, 1.0, 0.0,  1, 1, 200, 1000},
                 // test that read 2 (with mapping quality 1) is filtered out with minimum mapping quality 2
                 {TEST_DIR + "/lowmapq.sam",     intervals, 2, 0, true,  2, 202, 0,   0.0, 0.505, 0.0,   1, 0, 202, 1000},
-                {TEST_DIR + "/lowmapq.sam",     halfIntervals, 2, 0, true,  2, 202, 0,   0.0, 1.0, 0.0,   1, 1, 202, 1000},
                 // test that we clip overlapping bases
                 {TEST_DIR + "/overlapping.sam", intervals, 0, 0, true,  2, 202, 0,   0.5, 0.505, 0, 1, 0, 202, 1000},
-                {TEST_DIR + "/overlapping.sam", halfIntervals, 0, 0, true,  2, 202, 0,   0.5, 1.0, 0, 1, 1, 202, 1000},
                 // test that we do not clip overlapping bases
                 {TEST_DIR + "/overlapping.sam", intervals, 0, 0, false, 2, 202, 0,   0.0, 0.505, 0.505, 2, 0, 202, 1000},
+                // A shorter interval that is completely covered by the read.
+                // test that minimum coverage increases from zero when interval is completely covered by the read
+                // test that pct 1x (and 2x if counting overlap) coverage increases when the interval is completely covered by the read
+                {TEST_DIR + "/lowbaseq.sam",    halfIntervals, 1, 10, true,  2, 200, 0.5, 0.0, 1.0, 0.0,  1, 1, 200, 1000},
+                {TEST_DIR + "/lowmapq.sam",     halfIntervals, 2, 0, true,  2, 202, 0,   0.0, 1.0, 0.0,   1, 1, 202, 1000},
+                {TEST_DIR + "/overlapping.sam", halfIntervals, 0, 0, true,  2, 202, 0,   0.5, 1.0, 0, 1, 1, 202, 1000},
                 {TEST_DIR + "/overlapping.sam", halfIntervals, 0, 0, false, 2, 202, 0,   0.0, 1.0, 1.0, 2, 2, 202, 1000},
                 // A read 10 base pairs long. two intervals: one maps identically to the read, other does not overlap at all
                 {TEST_DIR + "/single-short-read.sam", twoSmallIntervals, 20, 20, true, 1, 10, 0.0, 0.0, 0.5, 0.0, 1, 0, 10, 1000 }
-
         };
     }
 

--- a/src/test/java/picard/analysis/directed/CollectHsMetricsTest.java
+++ b/src/test/java/picard/analysis/directed/CollectHsMetricsTest.java
@@ -29,20 +29,25 @@ public class CollectHsMetricsTest extends CommandLineProgramTest {
     public Object[][] targetedIntervalDataProvider() {
         final String referenceFile = TEST_DIR + "/chrM.fasta";
         final String intervals = TEST_DIR + "/chrM.interval_list";
+        final String halfIntervals = TEST_DIR + "/chrM_100bp.interval_list";
         final String twoSmallIntervals = TEST_DIR + "/two-small.interval_list";
 
         return new Object[][] {
                 // two reads, each has 100 bases. bases in one read are medium quality (20), in the other read poor quality (10).
                 // test that we exclude half of the bases
-                {TEST_DIR + "/lowbaseq.sam",    intervals, 1, 10, true,  2, 200, 0.5, 0.0, 0.50, 0.0,  1, 200, 1000},
+                {TEST_DIR + "/lowbaseq.sam",    intervals, 1, 10, true,  2, 200, 0.5, 0.0, 0.50, 0.0,  1, 0, 200, 1000},
+                {TEST_DIR + "/lowbaseq.sam",    halfIntervals, 1, 10, true,  2, 200, 0.5, 0.0, 1.0, 0.0,  1, 1, 200, 1000},
                 // test that read 2 (with mapping quality 1) is filtered out with minimum mapping quality 2
-                {TEST_DIR + "/lowmapq.sam",     intervals, 2, 0, true,  2, 202, 0,   0.0, 0.505, 0.0,   1, 202, 1000},
+                {TEST_DIR + "/lowmapq.sam",     intervals, 2, 0, true,  2, 202, 0,   0.0, 0.505, 0.0,   1, 0, 202, 1000},
+                {TEST_DIR + "/lowmapq.sam",     halfIntervals, 2, 0, true,  2, 202, 0,   0.0, 1.0, 0.0,   1, 1, 202, 1000},
                 // test that we clip overlapping bases
-                {TEST_DIR + "/overlapping.sam", intervals, 0, 0, true,  2, 202, 0,   0.5, 0.505, 0, 1, 202, 1000},
+                {TEST_DIR + "/overlapping.sam", intervals, 0, 0, true,  2, 202, 0,   0.5, 0.505, 0, 1, 0, 202, 1000},
+                {TEST_DIR + "/overlapping.sam", halfIntervals, 0, 0, true,  2, 202, 0,   0.5, 1.0, 0, 1, 1, 202, 1000},
                 // test that we do not clip overlapping bases
-                {TEST_DIR + "/overlapping.sam", intervals, 0, 0, false, 2, 202, 0,   0.0, 0.505, 0.505, 2, 202, 1000},
+                {TEST_DIR + "/overlapping.sam", intervals, 0, 0, false, 2, 202, 0,   0.0, 0.505, 0.505, 2, 0, 202, 1000},
+                {TEST_DIR + "/overlapping.sam", halfIntervals, 0, 0, false, 2, 202, 0,   0.0, 1.0, 1.0, 2, 2, 202, 1000},
                 // A read 10 base pairs long. two intervals: one maps identically to the read, other does not overlap at all
-                {TEST_DIR + "/single-short-read.sam", twoSmallIntervals, 20, 20, true, 1, 10, 0.0, 0.0, 0.5, 0.0, 1, 10, 1000 }
+                {TEST_DIR + "/single-short-read.sam", twoSmallIntervals, 20, 20, true, 1, 10, 0.0, 0.0, 0.5, 0.0, 1, 0, 10, 1000 }
 
         };
     }
@@ -80,6 +85,7 @@ public class CollectHsMetricsTest extends CommandLineProgramTest {
                                               final double pctTargetBases1x,
                                               final double pctTargetBases2x,
                                               final long maxTargetCoverage,
+                                              final long minTargetCoverage,
                                               final long pfBases,
                                               final int sampleSize) throws IOException {
 
@@ -107,6 +113,7 @@ public class CollectHsMetricsTest extends CommandLineProgramTest {
         Assert.assertEquals(metrics.PCT_TARGET_BASES_1X, pctTargetBases1x);
         Assert.assertEquals(metrics.PCT_TARGET_BASES_2X, pctTargetBases2x);
         Assert.assertEquals(metrics.MAX_TARGET_COVERAGE, maxTargetCoverage);
+        Assert.assertEquals(metrics.MIN_TARGET_COVERAGE, minTargetCoverage);
         Assert.assertEquals(metrics.PF_BASES, pfBases);
     }
 

--- a/testdata/picard/analysis/directed/CollectHsMetrics/chrM_100bp.interval_list
+++ b/testdata/picard/analysis/directed/CollectHsMetrics/chrM_100bp.interval_list
@@ -1,0 +1,3 @@
+@HD	VN:1.6	GO:none	SO:coordinate
+@SQ	SN:chrM	LN:16571	AS:HG18	UR:/seq/references/Homo_sapiens_assembly18/v0/Homo_sapiens_assembly18.fasta	M5:d2ed829b8a1628d16cbeee88e88e39eb	SP:Homo sapiens
+chrM	1	100	+	interval-1


### PR DESCRIPTION
### Description

The summary statistics provided by HsMetrics are helpful in determining how well a hybrid selection experiment worked, however currently they do not provide an indication if any target(s) achieved lower depth than the mean. While `ZERO_CVG_TARGETS` can help with this in extreme cases, it does not apply to instances when one target had very low non-zero coverage.

I think `MIN_TARGET_COVERAGE` is a natural addition to `MAX_` and `MEAN_` for summarizing a hybrid-selection experiment’s results.

Any thoughts?

----

### Checklist (never delete this)

Never delete this, it is our record that procedure was followed. If you find that for whatever reason one of the checklist points doesn't apply to your PR, you can leave it unchecked but please add an explanation below.

#### Content
- [x] Added or modified tests to cover changes and any new functionality
- [x] Edited the README / documentation (if applicable)
- [x] All tests passing on Travis

#### Review
- [ ] Final thumbs-up from reviewer
- [ ] Rebase, squash and reword as applicable

For more detailed guidelines, see https://github.com/broadinstitute/picard/wiki/Guidelines-for-pull-requests

